### PR TITLE
LPP-55323: null

### DIFF
--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
@@ -5,10 +5,23 @@
 
 package com.liferay.portal.search.web.internal.portlet.shared.search;
 
+import com.liferay.fragment.model.FragmentEntryLink;
+import com.liferay.fragment.service.FragmentEntryLinkLocalService;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.model.LayoutPageTemplateStructureRel;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
+import com.liferay.layout.page.template.service.LayoutPageTemplateStructureRelLocalService;
+import com.liferay.layout.util.structure.LayoutStructure;
+import com.liferay.layout.util.structure.LayoutStructureItem;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMap;
 import com.liferay.osgi.service.tracker.collections.map.ServiceTrackerMapFactory;
 import com.liferay.portal.kernel.dao.search.DisplayTerms;
 import com.liferay.portal.kernel.dao.search.SearchContainer;
+import com.liferay.portal.kernel.json.JSONException;
+import com.liferay.portal.kernel.json.JSONFactory;
+import com.liferay.portal.kernel.json.JSONObject;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutConstants;
 import com.liferay.portal.kernel.model.LayoutTypePortlet;
@@ -43,6 +56,7 @@ import com.liferay.portal.search.web.search.request.SearchSettingsContributor;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import javax.portlet.PortletRequest;
@@ -170,7 +184,8 @@ public class PortletSharedSearchRequestImpl
 	}
 
 	private List<Portlet> _getInstantiatedPortlets(
-		Layout layout, long companyId) {
+		Layout layout, long companyId, long groupId,
+		long[] segmentsExperienceIds) {
 
 		List<Portlet> portlets = new ArrayList<>();
 
@@ -179,9 +194,87 @@ public class PortletSharedSearchRequestImpl
 				PortletKeys.PREFS_OWNER_ID_DEFAULT,
 				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid());
 
+		List<String> portletIdsToFilter = new ArrayList<>();
+		List<String> instanceIdsToKeep = new ArrayList<>();
+
+		if ((segmentsExperienceIds != null) &&
+			(segmentsExperienceIds.length > 0)) {
+
+			LayoutPageTemplateStructure layoutPageTemplateStructure =
+				_layoutPageTemplateStructureLocalService.
+					fetchLayoutPageTemplateStructure(groupId, layout.getPlid());
+
+			if (layoutPageTemplateStructure != null) {
+				LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+					_layoutPageTemplateStructureRelLocalService.
+						fetchLayoutPageTemplateStructureRel(
+							layoutPageTemplateStructure.
+								getLayoutPageTemplateStructureId(),
+							segmentsExperienceIds[0]);
+
+				if (layoutPageTemplateStructureRel != null) {
+					LayoutStructure layoutStructure = LayoutStructure.of(
+						layoutPageTemplateStructureRel.getData());
+
+					Map<Long, LayoutStructureItem>
+						fragmentLayoutStructureItems =
+							layoutStructure.getFragmentLayoutStructureItems();
+
+					for (Map.Entry<Long, LayoutStructureItem>
+							fragmentLayoutStructureItem :
+								fragmentLayoutStructureItems.entrySet()) {
+
+						Long fragmentEntryLinkId =
+							fragmentLayoutStructureItem.getKey();
+
+						if (fragmentEntryLinkId <= 0) {
+							continue;
+						}
+
+						FragmentEntryLink fragmentEntryLink =
+							_fragmentEntryLinkLocalService.
+								fetchFragmentEntryLink(fragmentEntryLinkId);
+
+						if (fragmentEntryLink == null) {
+							continue;
+						}
+
+						try {
+							JSONObject editableValuesJSONObject =
+								_jsonFactory.createJSONObject(
+									fragmentEntryLink.getEditableValues());
+
+							portletIdsToFilter.add(
+								editableValuesJSONObject.getString(
+									"portletId"));
+
+							instanceIdsToKeep.add(
+								editableValuesJSONObject.getString(
+									"instanceId"));
+						}
+						catch (JSONException jsonException) {
+							if (_log.isDebugEnabled()) {
+								_log.debug(
+									"Error parsing fragment entry link JSON",
+									jsonException);
+							}
+						}
+					}
+				}
+			}
+		}
+
 		for (PortletPreferences portletPreferences : portletPreferencesList) {
 			Portlet portlet = portletLocalService.getPortletById(
 				companyId, portletPreferences.getPortletId());
+
+			if ((segmentsExperienceIds != null) &&
+				(segmentsExperienceIds.length > 0) &&
+				portletIdsToFilter.contains(portlet.getPortletName()) &&
+				!instanceIdsToKeep.contains(portlet.getInstanceId())) {
+
+				continue;
+			}
 
 			if (portlet.isInstanceable() &&
 				Validator.isNotNull(portlet.getInstanceId())) {
@@ -193,7 +286,10 @@ public class PortletSharedSearchRequestImpl
 		return portlets;
 	}
 
-	private List<Portlet> _getPortlets(Layout layout, long companyId) {
+	private List<Portlet> _getPortlets(
+		Layout layout, long companyId, long groupId,
+		long[] segmentsExperienceIds) {
+
 		LayoutTypePortlet layoutTypePortlet =
 			(LayoutTypePortlet)layout.getLayoutType();
 
@@ -204,7 +300,7 @@ public class PortletSharedSearchRequestImpl
 		}
 
 		List<Portlet> instantiatedPortlets = _getInstantiatedPortlets(
-			layout, companyId);
+			layout, companyId, groupId, segmentsExperienceIds);
 
 		for (Portlet instantiatedPortlet : instantiatedPortlets) {
 			if (!portlets.contains(instantiatedPortlet)) {
@@ -226,7 +322,7 @@ public class PortletSharedSearchRequestImpl
 		}
 
 		instantiatedPortlets = _getInstantiatedPortlets(
-			masterLayout, companyId);
+			masterLayout, companyId, groupId, segmentsExperienceIds);
 
 		for (Portlet instantiatedPortlet : instantiatedPortlets) {
 			if (!portlets.contains(instantiatedPortlet)) {
@@ -272,8 +368,12 @@ public class PortletSharedSearchRequestImpl
 		List<SearchSettingsContributor> searchSettingsContributors =
 			new ArrayList<>();
 
+		long[] segmentsExperienceIds = (long[])renderRequest.getAttribute(
+			"SEGMENTS_EXPERIENCE_IDS");
+
 		List<Portlet> portlets = _getPortlets(
-			themeDisplay.getLayout(), themeDisplay.getCompanyId());
+			themeDisplay.getLayout(), themeDisplay.getCompanyId(),
+			themeDisplay.getScopeGroupId(), segmentsExperienceIds);
 
 		for (Portlet portlet : portlets) {
 			SearchSettingsContributor searchSettingsContributor =
@@ -310,8 +410,25 @@ public class PortletSharedSearchRequestImpl
 			searchResponseImpl, portletSharedRequestHelper);
 	}
 
+	private static final Log _log = LogFactoryUtil.getLog(
+		PortletSharedSearchRequestImpl.class);
+
+	@Reference
+	private FragmentEntryLinkLocalService _fragmentEntryLinkLocalService;
+
+	@Reference
+	private JSONFactory _jsonFactory;
+
 	@Reference
 	private LayoutLocalService _layoutLocalService;
+
+	@Reference
+	private LayoutPageTemplateStructureLocalService
+		_layoutPageTemplateStructureLocalService;
+
+	@Reference
+	private LayoutPageTemplateStructureRelLocalService
+		_layoutPageTemplateStructureRelLocalService;
 
 	private ServiceTrackerMap<String, PortletSharedSearchContributor>
 		_serviceTrackerMap;

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
@@ -212,9 +212,11 @@ public class PortletSharedSearchRequestImpl
 		LayoutStructure layoutStructure = LayoutStructure.of(
 			layoutPageTemplateStructureRel.getData());
 
+		Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
+			layoutStructure.getFragmentLayoutStructureItems();
+
 		for (Map.Entry<Long, LayoutStructureItem> fragmentLayoutStructureItem :
-				layoutStructure.getFragmentLayoutStructureItems(
-				).entrySet()) {
+				fragmentLayoutStructureItems.entrySet()) {
 
 			Long fragmentEntryLinkId = fragmentLayoutStructureItem.getKey();
 

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
@@ -56,9 +56,11 @@ import com.liferay.portal.search.web.search.request.SearchSettings;
 import com.liferay.portal.search.web.search.request.SearchSettingsContributor;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
 
 import javax.portlet.PortletRequest;
 import javax.portlet.PortletURL;
@@ -184,6 +186,71 @@ public class PortletSharedSearchRequestImpl
 			searchRequestBuilderFactory);
 	}
 
+	private void _fetchPortletIdsAndInstanceIds(
+		Layout layout, long groupId, long segmentsExperienceId,
+		Set<String> portletIdsToFilter, Set<String> instanceIdsToKeep) {
+
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(groupId, layout.getPlid());
+
+		if (layoutPageTemplateStructure == null) {
+			return;
+		}
+
+		LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+			_layoutPageTemplateStructureRelLocalService.
+				fetchLayoutPageTemplateStructureRel(
+					layoutPageTemplateStructure.
+						getLayoutPageTemplateStructureId(),
+					segmentsExperienceId);
+
+		if (layoutPageTemplateStructureRel == null) {
+			return;
+		}
+
+		LayoutStructure layoutStructure = LayoutStructure.of(
+			layoutPageTemplateStructureRel.getData());
+
+		for (Map.Entry<Long, LayoutStructureItem> fragmentLayoutStructureItem :
+				layoutStructure.getFragmentLayoutStructureItems(
+				).entrySet()) {
+
+			Long fragmentEntryLinkId = fragmentLayoutStructureItem.getKey();
+
+			if (fragmentEntryLinkId <= 0) {
+				continue;
+			}
+
+			FragmentEntryLink fragmentEntryLink =
+				_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+					fragmentEntryLinkId);
+
+			if (fragmentEntryLink == null) {
+				continue;
+			}
+
+			try {
+				JSONObject editableValuesJSONObject =
+					_jsonFactory.createJSONObject(
+						fragmentEntryLink.getEditableValues());
+
+				portletIdsToFilter.add(
+					editableValuesJSONObject.getString("portletId"));
+
+				instanceIdsToKeep.add(
+					editableValuesJSONObject.getString("instanceId"));
+			}
+			catch (JSONException jsonException) {
+				if (_log.isDebugEnabled()) {
+					_log.debug(
+						"Error parsing fragment entry link JSON",
+						jsonException);
+				}
+			}
+		}
+	}
+
 	private List<Portlet> _getInstantiatedPortlets(
 		Layout layout, long companyId, long groupId,
 		long[] segmentsExperienceIds) {
@@ -212,68 +279,12 @@ public class PortletSharedSearchRequestImpl
 			return portlets;
 		}
 
-		List<String> portletIdsToFilter = new ArrayList<>();
-		List<String> instanceIdsToKeep = new ArrayList<>();
+		Set<String> portletIdsToFilter = new HashSet<>();
+		Set<String> instanceIdsToKeep = new HashSet<>();
 
-		LayoutPageTemplateStructure layoutPageTemplateStructure =
-			_layoutPageTemplateStructureLocalService.
-				fetchLayoutPageTemplateStructure(groupId, layout.getPlid());
-
-		if (layoutPageTemplateStructure != null) {
-			LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
-				_layoutPageTemplateStructureRelLocalService.
-					fetchLayoutPageTemplateStructureRel(
-						layoutPageTemplateStructure.
-							getLayoutPageTemplateStructureId(),
-						segmentsExperienceIds[0]);
-
-			if (layoutPageTemplateStructureRel != null) {
-				LayoutStructure layoutStructure = LayoutStructure.of(
-					layoutPageTemplateStructureRel.getData());
-
-				Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
-					layoutStructure.getFragmentLayoutStructureItems();
-
-				for (Map.Entry<Long, LayoutStructureItem>
-						fragmentLayoutStructureItem :
-							fragmentLayoutStructureItems.entrySet()) {
-
-					Long fragmentEntryLinkId =
-						fragmentLayoutStructureItem.getKey();
-
-					if (fragmentEntryLinkId <= 0) {
-						continue;
-					}
-
-					FragmentEntryLink fragmentEntryLink =
-						_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
-							fragmentEntryLinkId);
-
-					if (fragmentEntryLink == null) {
-						continue;
-					}
-
-					try {
-						JSONObject editableValuesJSONObject =
-							_jsonFactory.createJSONObject(
-								fragmentEntryLink.getEditableValues());
-
-						portletIdsToFilter.add(
-							editableValuesJSONObject.getString("portletId"));
-
-						instanceIdsToKeep.add(
-							editableValuesJSONObject.getString("instanceId"));
-					}
-					catch (JSONException jsonException) {
-						if (_log.isDebugEnabled()) {
-							_log.debug(
-								"Error parsing fragment entry link JSON",
-								jsonException);
-						}
-					}
-				}
-			}
-		}
+		_fetchPortletIdsAndInstanceIds(
+			layout, groupId, segmentsExperienceIds[0], portletIdsToFilter,
+			instanceIdsToKeep);
 
 		for (PortletPreferences portletPreferences : portletPreferencesList) {
 			Portlet portlet = portletLocalService.getPortletById(

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
@@ -279,14 +279,10 @@ public class PortletSharedSearchRequestImpl
 			Portlet portlet = portletLocalService.getPortletById(
 				companyId, portletPreferences.getPortletId());
 
-			if (portletIdsToFilter.contains(portlet.getPortletName()) &&
-				!instanceIdsToKeep.contains(portlet.getInstanceId())) {
-
-				continue;
-			}
-
 			if (portlet.isInstanceable() &&
-				Validator.isNotNull(portlet.getInstanceId())) {
+				Validator.isNotNull(portlet.getInstanceId()) &&
+				(!portletIdsToFilter.contains(portlet.getPortletName()) ||
+				 instanceIdsToKeep.contains(portlet.getInstanceId()))) {
 
 				portlets.add(portlet);
 			}

--- a/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
+++ b/modules/apps/portal-search/portal-search-web/src/main/java/com/liferay/portal/search/web/internal/portlet/shared/search/PortletSharedSearchRequestImpl.java
@@ -34,6 +34,7 @@ import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.PortletLocalService;
 import com.liferay.portal.kernel.service.PortletPreferencesLocalService;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
+import com.liferay.portal.kernel.util.ArrayUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
@@ -194,70 +195,80 @@ public class PortletSharedSearchRequestImpl
 				PortletKeys.PREFS_OWNER_ID_DEFAULT,
 				PortletKeys.PREFS_OWNER_TYPE_LAYOUT, layout.getPlid());
 
+		if (ArrayUtil.isEmpty(segmentsExperienceIds)) {
+			for (PortletPreferences portletPreferences :
+					portletPreferencesList) {
+
+				Portlet portlet = portletLocalService.getPortletById(
+					companyId, portletPreferences.getPortletId());
+
+				if (portlet.isInstanceable() &&
+					Validator.isNotNull(portlet.getInstanceId())) {
+
+					portlets.add(portlet);
+				}
+			}
+
+			return portlets;
+		}
+
 		List<String> portletIdsToFilter = new ArrayList<>();
 		List<String> instanceIdsToKeep = new ArrayList<>();
 
-		if ((segmentsExperienceIds != null) &&
-			(segmentsExperienceIds.length > 0)) {
+		LayoutPageTemplateStructure layoutPageTemplateStructure =
+			_layoutPageTemplateStructureLocalService.
+				fetchLayoutPageTemplateStructure(groupId, layout.getPlid());
 
-			LayoutPageTemplateStructure layoutPageTemplateStructure =
-				_layoutPageTemplateStructureLocalService.
-					fetchLayoutPageTemplateStructure(groupId, layout.getPlid());
+		if (layoutPageTemplateStructure != null) {
+			LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
+				_layoutPageTemplateStructureRelLocalService.
+					fetchLayoutPageTemplateStructureRel(
+						layoutPageTemplateStructure.
+							getLayoutPageTemplateStructureId(),
+						segmentsExperienceIds[0]);
 
-			if (layoutPageTemplateStructure != null) {
-				LayoutPageTemplateStructureRel layoutPageTemplateStructureRel =
-					_layoutPageTemplateStructureRelLocalService.
-						fetchLayoutPageTemplateStructureRel(
-							layoutPageTemplateStructure.
-								getLayoutPageTemplateStructureId(),
-							segmentsExperienceIds[0]);
+			if (layoutPageTemplateStructureRel != null) {
+				LayoutStructure layoutStructure = LayoutStructure.of(
+					layoutPageTemplateStructureRel.getData());
 
-				if (layoutPageTemplateStructureRel != null) {
-					LayoutStructure layoutStructure = LayoutStructure.of(
-						layoutPageTemplateStructureRel.getData());
+				Map<Long, LayoutStructureItem> fragmentLayoutStructureItems =
+					layoutStructure.getFragmentLayoutStructureItems();
 
-					Map<Long, LayoutStructureItem>
-						fragmentLayoutStructureItems =
-							layoutStructure.getFragmentLayoutStructureItems();
+				for (Map.Entry<Long, LayoutStructureItem>
+						fragmentLayoutStructureItem :
+							fragmentLayoutStructureItems.entrySet()) {
 
-					for (Map.Entry<Long, LayoutStructureItem>
-							fragmentLayoutStructureItem :
-								fragmentLayoutStructureItems.entrySet()) {
+					Long fragmentEntryLinkId =
+						fragmentLayoutStructureItem.getKey();
 
-						Long fragmentEntryLinkId =
-							fragmentLayoutStructureItem.getKey();
+					if (fragmentEntryLinkId <= 0) {
+						continue;
+					}
 
-						if (fragmentEntryLinkId <= 0) {
-							continue;
-						}
+					FragmentEntryLink fragmentEntryLink =
+						_fragmentEntryLinkLocalService.fetchFragmentEntryLink(
+							fragmentEntryLinkId);
 
-						FragmentEntryLink fragmentEntryLink =
-							_fragmentEntryLinkLocalService.
-								fetchFragmentEntryLink(fragmentEntryLinkId);
+					if (fragmentEntryLink == null) {
+						continue;
+					}
 
-						if (fragmentEntryLink == null) {
-							continue;
-						}
+					try {
+						JSONObject editableValuesJSONObject =
+							_jsonFactory.createJSONObject(
+								fragmentEntryLink.getEditableValues());
 
-						try {
-							JSONObject editableValuesJSONObject =
-								_jsonFactory.createJSONObject(
-									fragmentEntryLink.getEditableValues());
+						portletIdsToFilter.add(
+							editableValuesJSONObject.getString("portletId"));
 
-							portletIdsToFilter.add(
-								editableValuesJSONObject.getString(
-									"portletId"));
-
-							instanceIdsToKeep.add(
-								editableValuesJSONObject.getString(
-									"instanceId"));
-						}
-						catch (JSONException jsonException) {
-							if (_log.isDebugEnabled()) {
-								_log.debug(
-									"Error parsing fragment entry link JSON",
-									jsonException);
-							}
+						instanceIdsToKeep.add(
+							editableValuesJSONObject.getString("instanceId"));
+					}
+					catch (JSONException jsonException) {
+						if (_log.isDebugEnabled()) {
+							_log.debug(
+								"Error parsing fragment entry link JSON",
+								jsonException);
 						}
 					}
 				}
@@ -268,9 +279,7 @@ public class PortletSharedSearchRequestImpl
 			Portlet portlet = portletLocalService.getPortletById(
 				companyId, portletPreferences.getPortletId());
 
-			if ((segmentsExperienceIds != null) &&
-				(segmentsExperienceIds.length > 0) &&
-				portletIdsToFilter.contains(portlet.getPortletName()) &&
+			if (portletIdsToFilter.contains(portlet.getPortletName()) &&
 				!instanceIdsToKeep.contains(portlet.getInstanceId())) {
 
 				continue;


### PR DESCRIPTION
Ticket: https://liferay.atlassian.net/browse/LPP-55323

Context of the Changes:

The only way  to determine the portletId based on a given segment_experience_id was through the following process:

Using the layoutPageTemplateStructure table, we start with the layoutPageTemplateStructureId.
By combining this with the segment_experience_id, we retrieve the layoutPageTemplateStructureRel.data.fragmentEntryLinkId.
With the fragmentEntryLinkId, we can then identify the FragmentEntryLink.portletId and FragmentEntryLink.instanceId.

In summary:

From layout.plid, we obtain the layoutPageTemplateStructure.LayoutPageTemplateStructureId.
Using segment_experience_id, we can retrieve the layoutPageTemplateStructureRel.data.fragmentEntryLinkId.
Finally, this leads us to the FragmentEntryLink.portletId and FragmentEntryLink.instanceId.
With the correct portletId and instanceId in hand, we can precisely filter and target the specific portlet that requires contributions.

![image](https://github.com/user-attachments/assets/3a428fdf-cf2f-46a3-95b6-049745e7be96)


